### PR TITLE
Update for ActiveRecord 6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkmf.log
 /.idea
 db.log
 test.sqlite3
+/gemfiles

--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,26 @@
+appraise "ar-50" do
+    ruby '~> 2'
+
+    gem 'activerecord', '~> 5.0.0'
+    gem 'sqlite3', '~> 1.3.6'
+end
+
+appraise "ar-51" do
+    ruby '~> 2'
+
+    gem 'activerecord', '~> 5.1.0'
+end
+
+appraise "ar-52" do
+    ruby '~> 2'
+
+    gem 'activerecord', '~> 5.2.0'
+end
+
+appraise "ar-60" do
+    gem 'activerecord', '~> 6.0.0'
+end
+
+appraise "ar-61" do
+    gem 'activerecord', '~> 6.1.0'
+end

--- a/acts_as_recursive_tree.gemspec
+++ b/acts_as_recursive_tree.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files            = spec.files.grep(%r{^spec/})
   spec.require_paths         = ['lib']
 
-  spec.add_runtime_dependency 'activerecord', '>= 5.0.0', '< 6.1.0'
+  spec.add_runtime_dependency 'activerecord', '>= 5.0.0', '< 6.2.0'
 
   spec.add_development_dependency 'database_cleaner', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/acts_as_recursive_tree.gemspec
+++ b/acts_as_recursive_tree.gemspec
@@ -6,8 +6,8 @@ require 'acts_as_recursive_tree/version'
 Gem::Specification.new do |spec|
   spec.name        = 'acts_as_recursive_tree'
   spec.version     = ActsAsRecursiveTree::VERSION
-  spec.authors     = ['Wolfgang Wedelich-John']
-  spec.email       = ['wolfgang.wedelich@1und1.de']
+  spec.authors     = ['Wolfgang Wedelich-John', 'Willem Mulder']
+  spec.email       = ['wolfgang.wedelich@1und1.de', '14mRh4X0r@gmail.com']
   spec.summary     = %q{Drop in replacement for acts_as_tree but using recursive queries}
   spec.description = %q{
   This is a ruby gem that provides drop in replacement for acts_as_tree but makes use of SQL recursive statement. Be sure to have a DBMS that supports recursive queries when using this gem (e.g. PostgreSQL or SQLite). }
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.5'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'appraisal', '~> 2.4'
 end

--- a/lib/acts_as_recursive_tree/options/values.rb
+++ b/lib/acts_as_recursive_tree/options/values.rb
@@ -38,6 +38,16 @@ module ActsAsRecursiveTree
         end
       end
 
+      class RangeValue < Base
+        def apply_to(attribute)
+          attribute.between(prepared_value)
+        end
+
+        def apply_negated_to(attribute)
+          attribute.not_between(prepared_value)
+        end
+      end
+
       class MultiValue < Base
         def apply_to(attribute)
           attribute.in(prepared_value)
@@ -62,6 +72,8 @@ module ActsAsRecursiveTree
           SingleValue
         when ::ActiveRecord::Relation
           Relation
+        when Range
+          RangeValue
         when Enumerable
           MultiValue
         when ::ActiveRecord::Base

--- a/lib/acts_as_recursive_tree/version.rb
+++ b/lib/acts_as_recursive_tree/version.rb
@@ -1,3 +1,3 @@
 module ActsAsRecursiveTree
-  VERSION = '2.2.0'.freeze
+  VERSION = '2.2.1'.freeze
 end

--- a/spec/db/database.rb
+++ b/spec/db/database.rb
@@ -8,10 +8,16 @@ ActiveRecord::Migration.verbose = false
 
 ActiveRecord::Base.configurations = YAML::load(File.read("#{database_folder}/database.yml"))
 
-config = ActiveRecord::Base.configurations[database_adapter]
+if ActiveRecord.version >= Gem::Version.new('6.1.0')
+  config = ActiveRecord::Base.configurations.configs_for env_name: database_adapter, name: "primary"
+  database = config.database
+else
+  config = ActiveRecord::Base.configurations[database_adapter]
+  database = config["database"]
+end
 
 # remove database if present
-FileUtils.rm config['database'], force: true
+FileUtils.rm database, force: true
 
 ActiveRecord::Base.establish_connection(database_adapter.to_sym)
 ActiveRecord::Base.establish_connection(config)

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -57,7 +57,7 @@ describe ActsAsRecursiveTree::Options::Values do
       let(:range) { 1..3 }
       subject(:value) { described_class.create(range) }
 
-      it { is_expected.to be_a ActsAsRecursiveTree::Options::Values::MultiValue }
+      it { is_expected.to be_a ActsAsRecursiveTree::Options::Values::RangeValue }
 
       it 'should apply_to' do
         expect(value.apply_to(attribute).to_sql).to end_with "BETWEEN #{range.begin} AND #{range.end}"


### PR DESCRIPTION
Using `Arel::Predications#in` with Ranges has been deprecated since Arel 6 (Rails 4.2). In ActiveRecord 6.1, special casing for Ranges has been removed, so I added a new class `ActsAsRecursiveTree::Options::Values::RangeValue` specifically for ranges, which calls `#between` instead.